### PR TITLE
Enable uploads

### DIFF
--- a/conf/CustomSettings.php
+++ b/conf/CustomSettings.php
@@ -13,13 +13,13 @@ $wgDevelopmentWarnings = true;
 $wgLogo               = "";
 $wgEmergencyContact = "hlpwikiadmin@agileventures.org";
 $wgPasswordSender   = "hlpwikiadmin@agileventures.org";
+$wgEnableUploads    = true;
 
 if (getenv('MEDIAWIKI_DISABLE_ANONYMOUS_EDIT')) {
     $wgGroupPermissions['*']['edit'] = false;
 }
 $wgGroupPermissions['moderator']['editinterface'] = true;
 $wgGroupPermissions['user']['editinterface'] = true;
-$wgDisableUploads = false;
 $wgUsersNotifiedOnAllChanges = array('User', 'Tansaku');
 $wgFooterIcons['poweredby']['myicon'] = array(
     "src" => "https://dl.dropbox.com/s/1kekg96rkndea64/customized-by-agileventures-176wide.png?dl=1",


### PR DESCRIPTION
Fixes #7 

Uploads are disabled by default with mediawiki 1.31, so you must add a line to enable them