### PR TITLE
Configure sendgrid mail services

### DIFF
--- a/conf/CustomSettings.php
+++ b/conf/CustomSettings.php
@@ -10,6 +10,10 @@ $wgDebugToolbar = true;
 $wgShowDebug = true;
 $wgDevelopmentWarnings = true;
 
+$wgEnableUserEmail     = true;
+$wgEnotifWatchlist     = true; # UPO
+$wgEmailAuthentication = true;
+
 $wgLogo               = "";
 $wgEmergencyContact = "hlpwikiadmin@agileventures.org";
 $wgPasswordSender   = "hlpwikiadmin@agileventures.org";
@@ -20,7 +24,21 @@ if (getenv('MEDIAWIKI_DISABLE_ANONYMOUS_EDIT')) {
 $wgGroupPermissions['moderator']['editinterface'] = true;
 $wgGroupPermissions['user']['editinterface'] = true;
 $wgDisableUploads = false;
+
 $wgUsersNotifiedOnAllChanges = array('User', 'Tansaku');
+$SENDGRID_API_KEY_PASSWORD = getenv('SENDGRID_API_KEY_PASSWORD');
+
+$wgSMTP = [
+    'host'     => 'ssl://smtp.sendgrid.net',
+    'IDHost'   => 'sendgrid.net',
+    'port'     => '465',
+    'auth'     => true,
+    'username' => 'apikey',
+    'password' => $SENDGRID_API_KEY_PASSWORD,
+];
+
+$wgDefaultUserOptions['enotifwatchlistpages'] = true;
+
 $wgFooterIcons['poweredby']['myicon'] = array(
     "src" => "https://dl.dropbox.com/s/1kekg96rkndea64/customized-by-agileventures-176wide.png?dl=1",
     "url" => "http://nonprofits.agileventures.org/",


### PR DESCRIPTION
Fixes #10 

Notes while working on this:

Set the username of SendGrid to 'apikey' as per their instructions in the email sent to us with this relevant text 

> Try using an API key with full permissions for SMTP mail send authentication instead of your username/password.  For username, use "apikey" (just that single word). For the password, use a valid API key as the password (the actual 69 character API key).

API key is stored where only @tansaku can access it, so I have set the variable `$SENDGRID_API_KEY_PASSWORD` and will ask him to add it to Dokku config. 

I am having some difficulty to know exactly what needs to be set in the `CustomSettings.php` file with regards to configuring the email to what we currently have as I have access to the `hlpwiki-production-clone` and its LocalSettings.php, but some of those variables will have been set at the creation of LocalSettings.php in `entrypoint.sh`, but I don't have access to look at that. 

I have tried to entering the docker container, which runs the entrypoint scripts, but it does not have access to the env variables in the dokku side so it doesn't actually create a LocalSettings.php... 

I have resolved to checking default values on email settings one by one on https://www.mediawiki.org/wiki/Manual:<variable>

It seems to me that `$wgEnableEmail` is true by default. Anything that is the same in our production clone LocalSettings.php as the default I am not adding to the CustomSettings.php

`$wgEnableUserEmail` set to true
`$wgEnotifUserTalk`, same as default
`$wgEnotifWatchlist` set to true
`$wgEmailAuthentication` set to true

added this line `$wgDefaultUserOptions['enotifwatchlistpages'] = true;`