### PR TITLE
12 add semantic mediawiki extension

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM mediawiki:1.31
 
-RUN apt-get update -qq && apt-get install wget
+RUN apt-get update -qq && apt-get install -y wget zip
 
 COPY conf /conf
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,10 +4,9 @@ RUN apt-get update -qq && apt-get install -y wget zip
 
 COPY conf /conf
 
-COPY dokku-entrypoint.sh /dokku-entrypoint.sh
-COPY entrypoint.sh /entrypoint.sh
-COPY composer-install.sh /composer-install.sh
-COPY composer.local.json /composer.local.json
+COPY dokku-entrypoint.sh entrypoint.sh \ 
+     composer-install.sh composer.local.json \ 
+     install-update-php-dependencies.sh /
 COPY extensions /var/www/html/extensions
 
 EXPOSE 80 443

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,13 @@
 FROM mediawiki:1.31
 
+RUN apt-get update -qq && apt-get install wget
+
 COPY conf /conf
 
 COPY dokku-entrypoint.sh /dokku-entrypoint.sh
 COPY entrypoint.sh /entrypoint.sh
+COPY composer-install.sh /composer-install.sh
+COPY composer.local.json /composer.local.json
 COPY extensions /var/www/html/extensions
 
 EXPOSE 80 443

--- a/composer-install.sh
+++ b/composer-install.sh
@@ -1,0 +1,17 @@
+#!/bin/sh
+
+EXPECTED_SIGNATURE="$(wget -q -O - https://composer.github.io/installer.sig)"
+php -r "copy('https://getcomposer.org/installer', 'composer-setup.php');"
+ACTUAL_SIGNATURE="$(php -r "echo hash_file('SHA384', 'composer-setup.php');")"
+
+if [ "$EXPECTED_SIGNATURE" != "$ACTUAL_SIGNATURE" ]
+then
+    >&2 echo 'ERROR: Invalid installer signature'
+    rm composer-setup.php
+    exit 1
+fi
+
+php composer-setup.php --quiet
+RESULT=$?
+rm composer-setup.php
+exit $RESULT

--- a/composer.local.json
+++ b/composer.local.json
@@ -1,0 +1,7 @@
+{
+  "require": {
+      "mediawiki/parser-hooks": "~1",
+      "mediawiki/validator": "~2",
+      "mediawiki/semantic-media-wiki": "~3.0"
+  }
+}

--- a/conf/CustomSettings.php
+++ b/conf/CustomSettings.php
@@ -105,3 +105,6 @@ $wgModerationNotificationEnable = true;
 $wgModerationNotificationNewOnly = false;
 $wgModerationEmail = $wgEmergencyContact;
 
+## Semantic Extension
+enableSemantics( 'healthylondon.org' );
+

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -24,10 +24,11 @@ if [ ! -e "LocalSettings.php" -a ! -z "$MEDIAWIKI_SITE_SERVER" ]; then
 
         # Append inclusion of /compose_conf/CustomSettings.php
         echo "@include('/conf/CustomSettings.php');" >> LocalSettings.php
-				/composer-install.sh
-				php composer.phar require mediawiki/semantic-media-wiki "~3.0" --update-no-dev
-				php maintenance/update.php --quick --conf ./LocalSettings.php
 fi
+
+/composer-install.sh
+php composer.phar require mediawiki/semantic-media-wiki "~3.0" --update-no-dev
+php composer.phar update --no-dev
 
 echo "MEDIAWIKI_UPDATE: $MEDIAWIKI_UPDATE"
 if [ -e "LocalSettings.php" -a $MEDIAWIKI_UPDATE = true ]; then

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -24,11 +24,9 @@ if [ ! -e "LocalSettings.php" -a ! -z "$MEDIAWIKI_SITE_SERVER" ]; then
 
         # Append inclusion of /compose_conf/CustomSettings.php
         echo "@include('/conf/CustomSettings.php');" >> LocalSettings.php
+				/composer-install.sh
+				php composer.phar require mediawiki/semantic-media-wiki "~3.0" --update-no-dev
 fi
-
-/composer-install.sh
-php composer.phar require mediawiki/semantic-media-wiki "~3.0" --update-no-dev
-php setupStore.php 
 
 echo "MEDIAWIKI_UPDATE: $MEDIAWIKI_UPDATE"
 if [ -e "LocalSettings.php" -a $MEDIAWIKI_UPDATE = true ]; then

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -28,6 +28,7 @@ fi
 
 /composer-install.sh
 php composer.phar require mediawiki/semantic-media-wiki "~3.0" --update-no-dev
+php setupStore.php 
 
 echo "MEDIAWIKI_UPDATE: $MEDIAWIKI_UPDATE"
 if [ -e "LocalSettings.php" -a $MEDIAWIKI_UPDATE = true ]; then

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -26,6 +26,7 @@ if [ ! -e "LocalSettings.php" -a ! -z "$MEDIAWIKI_SITE_SERVER" ]; then
         echo "@include('/conf/CustomSettings.php');" >> LocalSettings.php
 				/composer-install.sh
 				php composer.phar require mediawiki/semantic-media-wiki "~3.0" --update-no-dev
+				php maintenance/update.php --quick --conf ./LocalSettings.php
 fi
 
 echo "MEDIAWIKI_UPDATE: $MEDIAWIKI_UPDATE"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -25,6 +25,10 @@ if [ ! -e "LocalSettings.php" -a ! -z "$MEDIAWIKI_SITE_SERVER" ]; then
         # Append inclusion of /compose_conf/CustomSettings.php
         echo "@include('/conf/CustomSettings.php');" >> LocalSettings.php
 fi
+
+/composer-install.sh
+php composer.phar require mediawiki/semantic-media-wiki "~3.0" --update-no-dev
+
 echo "MEDIAWIKI_UPDATE: $MEDIAWIKI_UPDATE"
 if [ -e "LocalSettings.php" -a $MEDIAWIKI_UPDATE = true ]; then
 	echo >&2 'info: Running maintenance/update.php';

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -27,8 +27,7 @@ if [ ! -e "LocalSettings.php" -a ! -z "$MEDIAWIKI_SITE_SERVER" ]; then
 fi
 
 /composer-install.sh
-php composer.phar require mediawiki/semantic-media-wiki "3.0.0" --update-no-dev
-php composer.phar update --no-dev
+/install-update-php-dependencies.sh
 
 echo "MEDIAWIKI_UPDATE: $MEDIAWIKI_UPDATE"
 if [ -e "LocalSettings.php" -a $MEDIAWIKI_UPDATE = true ]; then

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -27,7 +27,7 @@ if [ ! -e "LocalSettings.php" -a ! -z "$MEDIAWIKI_SITE_SERVER" ]; then
 fi
 
 /composer-install.sh
-php composer.phar require mediawiki/semantic-media-wiki "~3.0" --update-no-dev
+php composer.phar require mediawiki/semantic-media-wiki "3.0.0" --update-no-dev
 php composer.phar update --no-dev
 
 echo "MEDIAWIKI_UPDATE: $MEDIAWIKI_UPDATE"

--- a/install-update-php-dependencies.sh
+++ b/install-update-php-dependencies.sh
@@ -1,0 +1,2 @@
+php composer.phar require mediawiki/semantic-media-wiki "3.0.0" --update-no-dev
+php composer.phar update --no-dev


### PR DESCRIPTION
Fixes #12 

Notes while installing:
I started with this site https://www.semantic-mediawiki.org/wiki/Help:Installation/Using_Composer_with_MediaWiki_1.25%2B

This says that the first step is to install composer and since the idea is to reuse this for automatic updates, I got forwarded to this page https://getcomposer.org/doc/faqs/how-to-install-composer-programmatically.md

I created a script to install Composer programmatically. 

After this, I added the "initialization" command from the first site above, but changed the version to "~3.0" as directed `php composer.phar require mediawiki/semantic-media-wiki "~3.0" --update-no-dev`

There is a paragraph from the same site that talks about why a `composer.local.json` should be added and links here: https://www.semantic-mediawiki.org/wiki/Help:Installation/Example_%22composer.local.json%22_file

I added the most simple example to the `composer.local.json` and copied the file over to the container

I then ran `docker build .`, enter the container with `docker run -it <CONTAINER ID> /bin/bash` and that ran the entrypoint script and that gave this output: https://gist.github.com/mattwr18/9eae4fc90d8dd5a92e6aae91068c98af#file-semantic-mediawiki-composer-install-output-txt

It warns against using composer as root and after some time trying to see if I could run it as user, I moved on as it seemed to be installing the dependencies. The other thing I noticed is that it is uninstalling 3 dependencies, this one seems like would be necessary for mailing services, so let's see: `Removing pear/net_smtp`

I pushed it up and got an error page saying I needed to run the `update.php`, which I am already doing, so I went to the logs and noticed what I hadn't noticed in the output above, which is that all the dependencies were failing due to not having `zip` installed. 

After adding it to the `Dockerfile`, I pushed it back up and that installed all the dependencies, but I noticed it wasn't running the update script and no change in the browser. 

I noticed some important output  `mediawiki/semantic-media-wiki: 3.0.0 installed, ~3.0 required.`, which I ignored at first because I got distracted by this `Error: your composer.lock file is not up to date. Run "composer update --no-dev" to install newer dependencies`

I headed back over to my entrypoint script and added a line to run the update with composer. Pushing it back up resulted in this dependency being updated `Updating pear/pear-core-minimal (v1.10.3 => v1.10.6)`, but otherwise no change. 

That led me back to that other output, which warned about different semantic-mediawikis installed and required. I changed that in the `php composer.php require...` command and then it all seemed to start working. 

Site is back up, and Semantic MediaWiki, is in the list in `Special:Version` extensions installed. 
I extracted the install and update commands to a script to clean up.




 


