### PR TITLE
Avoid installing unneccessary extensions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,6 @@ RUN apt-get update -qq && apt-get install -y software-properties-common apt-tran
     mv ./images ./images-old && ln -s /storage/images ./ && cd /var/www/html/extensions && \
     curl -L https://extdist.wmflabs.org/dist/extensions/CookieWarning-REL1_31-8ab2dfc.tar.gz | tar xz && \
     curl -L https://extdist.wmflabs.org/dist/extensions/MsUpload-REL1_31-d854ddf.tar.gz | tar xz && \
-    curl -L https://gitlab.com/Aranad/extensions/-/archive/master/extensions-master.tar.gz | tar xz && \
     rm -rf /var/lib/apt/lists/*
 
 COPY parsoid /etc/mediawiki/parsoid


### PR DESCRIPTION
This is a clean up from and earlier `PR` where I had added this in an attempt to avoid adding more third-party php file to our repo, but it was unsuccessful.

This is only installing a bunch of extensions from Aranad which we don't use
fixes#78