### PR TITLE
improve search 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ COPY parsoid /etc/mediawiki/parsoid
 COPY conf /conf
 COPY dokku-entrypoint.sh entrypoint.sh \ 
      composer-install.sh composer.local.json \ 
-     install-update-php-dependencies.sh /
+     install-update-php-dependencies.sh install-extensions.sh /
 COPY extensions extensions/
 COPY VectorTemplate.php skins/Vector/includes/VectorTemplate.php
 COPY nginx.conf.sigil .htaccess ./

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM mediawiki:1.31
 RUN apt-get update -qq && apt-get install -y software-properties-common apt-transport-https gnupg wget zip && \
     curl -sL https://deb.nodesource.com/setup_8.x | bash - && \
     apt-get update -qq && apt-add-repository "deb https://releases.wikimedia.org/debian jessie-mediawiki main" && \
-    apt-get update -qq && apt-get install -y ghostscript poppler-utils nodejs parsoid --allow-unauthenticated --no-install-recommends && \
+    apt-get update -qq && apt-get install -y ghostscript poppler-utils nodejs parsoid --allow-unauthenticated --no-install-recommends --fix-missing && \
     mv ./images ./images-old && ln -s /storage/images ./ && cd /var/www/html/extensions && \
     curl -L https://extdist.wmflabs.org/dist/extensions/CookieWarning-REL1_31-8ab2dfc.tar.gz | tar xz && \
     curl -L https://extdist.wmflabs.org/dist/extensions/MsUpload-REL1_31-d854ddf.tar.gz | tar xz && \

--- a/composer.local.json
+++ b/composer.local.json
@@ -4,6 +4,8 @@
       "mediawiki/validator": "~2",
       "mediawiki/semantic-media-wiki": "~3.0",
       "pear/mail": "1.4.*",
-      "pear/Net_SMTP": "1.8.*"
+      "pear/Net_SMTP": "1.8.*",
+      "elasticsearch/elasticsearch": "~6.0",
+      "ruflin/elastica": "~6.0"
   }
 }

--- a/composer.local.json
+++ b/composer.local.json
@@ -5,7 +5,6 @@
       "mediawiki/semantic-media-wiki": "~3.0",
       "pear/mail": "1.4.*",
       "pear/Net_SMTP": "1.8.*",
-      "elasticsearch/elasticsearch": "~6.0",
-      "ruflin/elastica": "~6.0"
+      "elasticsearch/elasticsearch": "~6.0"
   }
 }

--- a/conf/CustomSettings.php
+++ b/conf/CustomSettings.php
@@ -201,6 +201,10 @@ $wgHooks['HtmlPageLinkRendererBegin'][] = function ( $linkRenderer, $target, &$t
 
 require_once "$IP/extensions/SimpleEmbed/SimpleEmbed.php";
 
+## Elastica
+
+wfLoadExtension( 'Elastica' );
+
 ## Moderation Extension
 
 wfLoadExtension('Moderation');

--- a/conf/CustomSettings.php
+++ b/conf/CustomSettings.php
@@ -205,6 +205,10 @@ require_once "$IP/extensions/SimpleEmbed/SimpleEmbed.php";
 
 wfLoadExtension( 'Elastica' );
 
+## CirrusSearch
+
+require_once "$IP/extensions/CirrusSearch/CirrusSearch.php";
+
 ## Moderation Extension
 
 wfLoadExtension('Moderation');

--- a/conf/CustomSettings.php
+++ b/conf/CustomSettings.php
@@ -189,12 +189,12 @@ require_once "$IP/extensions/RecentActivity/RecentActivity.php";
 
 ## Default to Visual Editor for page creation
 
-$wgHooks['HtmlPageLinkRendererBegin'][] = function ( $linkRenderer, $target, &$text, &$extraAttribs, &$query, &$ret ) {
-	$title = Title::newFromLinkTarget( $target );
-	if ( !$title->isKnown() ) {
-		$query['veaction'] = 'edit';
-		$query['action'] = 'view'; // Prevent MediaWiki from overriding veaction
-	}
+$wgHooks['HtmlPageLinkRendererBegin'][] = function ($linkRenderer, $target, &$text, &$extraAttribs, &$query, &$ret) {
+    $title = Title::newFromLinkTarget($target);
+    if (!$title->isKnown()) {
+        $query['veaction'] = 'edit';
+        $query['action'] = 'view'; // Prevent MediaWiki from overriding veaction
+    }
 };
 
 ## SimpleEmbed
@@ -203,11 +203,15 @@ require_once "$IP/extensions/SimpleEmbed/SimpleEmbed.php";
 
 ## Elastica
 
-wfLoadExtension( 'Elastica' );
+wfLoadExtension('Elastica');
 
 ## CirrusSearch
 
 require_once "$IP/extensions/CirrusSearch/CirrusSearch.php";
+
+## AdvancedSearch
+
+wfLoadExtension('AdvancedSearch');
 
 ## Moderation Extension
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -3,7 +3,7 @@ set -x
 
 /composer-install.sh
 /install-update-php-dependencies.sh
-
+ 
 sed -i "/MEDIAWIKI_SITE_SERVER/c\        uri: '$MEDIAWIKI_SITE_SERVER/api.php'" /etc/mediawiki/parsoid/config.yaml
 
 # If there is no LocalSettings.php, create one using maintenance/install.php

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -3,6 +3,7 @@ set -x
 
 /composer-install.sh
 /install-update-php-dependencies.sh
+/install-extensions.sh
  
 sed -i "/MEDIAWIKI_SITE_SERVER/c\        uri: '$MEDIAWIKI_SITE_SERVER/api.php'" /etc/mediawiki/parsoid/config.yaml
 

--- a/install-extensions.sh
+++ b/install-extensions.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+cd extensions && \ 
+curl -L https://extdist.wmflabs.org/dist/extensions/Elastica-REL1_31-7019d96.tar.gz | tar xz && \
+cd Elastica && php /var/www/html/composer.phar install --no-dev

--- a/install-extensions.sh
+++ b/install-extensions.sh
@@ -3,4 +3,5 @@
 cd extensions && \ 
 curl -L https://extdist.wmflabs.org/dist/extensions/Elastica-REL1_31-7019d96.tar.gz | tar xz && \
 curl -L https://extdist.wmflabs.org/dist/extensions/CirrusSearch-REL1_31-ad9a0d9.tar.gz | tar xz && \
+curl -L https://extdist.wmflabs.org/dist/extensions/AdvancedSearch-REL1_31-be35a55.tar.gz | tar xz && \
 cd Elastica && php /var/www/html/composer.phar install --no-dev

--- a/install-extensions.sh
+++ b/install-extensions.sh
@@ -2,4 +2,5 @@
 
 cd extensions && \ 
 curl -L https://extdist.wmflabs.org/dist/extensions/Elastica-REL1_31-7019d96.tar.gz | tar xz && \
+curl -L https://extdist.wmflabs.org/dist/extensions/CirrusSearch-REL1_31-ad9a0d9.tar.gz | tar xz && \
 cd Elastica && php /var/www/html/composer.phar install --no-dev

--- a/install-update-php-dependencies.sh
+++ b/install-update-php-dependencies.sh
@@ -2,5 +2,4 @@ COMPOSER_ALLOW_SUPERUSER=true php composer.phar require mediawiki/semantic-media
 COMPOSER_ALLOW_SUPERUSER=true php composer.phar require pear/mail "1.4.1" --update-no-dev
 COMPOSER_ALLOW_SUPERUSER=true php composer.phar require pear/net_smtp "1.8.1" --update-no-dev
 COMPOSER_ALLOW_SUPERUSER=true php composer.phar require elasticsearch/elasticsearch "~6.0" --update-no-dev
-COMPOSER_ALLOW_SUPERUSER=true php composer.phar require ruflin/elastica "~6.0" --update-no-dev
 COMPOSER_ALLOW_SUPERUSER=true php composer.phar update --no-dev

--- a/install-update-php-dependencies.sh
+++ b/install-update-php-dependencies.sh
@@ -1,4 +1,6 @@
 COMPOSER_ALLOW_SUPERUSER=true php composer.phar require mediawiki/semantic-media-wiki "3.0.0" --update-no-dev
 COMPOSER_ALLOW_SUPERUSER=true php composer.phar require pear/mail "1.4.1" --update-no-dev
 COMPOSER_ALLOW_SUPERUSER=true php composer.phar require pear/net_smtp "1.8.1" --update-no-dev
+COMPOSER_ALLOW_SUPERUSER=true php composer.phar require elasticsearch/elasticsearch "~6.0" --update-no-dev
+COMPOSER_ALLOW_SUPERUSER=true php composer.phar require ruflin/elastica "~6.0" --update-no-dev
 COMPOSER_ALLOW_SUPERUSER=true php composer.phar update --no-dev


### PR DESCRIPTION
Addresses https://trello.com/c/ta7Uh3KD/77-find-a-way-to-minimize-what-appears-above-the-fold-on-search-results-page

to change the interface of the `Special:Search`, I researched some online, which led me to Wikipedia's search... I saw that they use `AdvancedSearch`, which looks nice... https://www.mediawiki.org/wiki/Extension:AdvancedSearch

This extension relies on https://www.mediawiki.org/wiki/Extension:CirrusSearch, which has `ElasticSearch` as a dependency, and also requires to install https://www.mediawiki.org/wiki/Extension:Elastica

Maybe this is overkill(?)... my hope is that there are other benefits to having custom search extensions... for example CirrusSearch features can be used in API queries. 